### PR TITLE
Checkbox CSS 오류 수정

### DIFF
--- a/client/src/components/views/RegisterPage/RegisterPage.js
+++ b/client/src/components/views/RegisterPage/RegisterPage.js
@@ -203,7 +203,9 @@ function RegisterPage(props) {
                 checked={agreed}
                 onChange={() => checkAgree("agree")}
               />
-              <label htmlFor="agree"></label>
+              <label htmlFor="agree">
+                {agreed && <img src="/images/checkbox.png" alt="checked" />}
+              </label>
               <button className="AgreeLink" onClick={handlePopup}>
                 [필수] 개인정보 수집 및 이용 동의
               </button>

--- a/client/src/components/views/RegisterPage/Sections/RegisterPage.css
+++ b/client/src/components/views/RegisterPage/Sections/RegisterPage.css
@@ -190,7 +190,7 @@ input[id="agree"] + label {
   cursor: pointer;
 }
 input[id="agree"]:checked + label {
-  background-image: url("/images/checkbox.png");
+  /* background-image: url("/images/checkbox.png"); */
   background-repeat: no-repeat;
 
   border: none;


### PR DESCRIPTION
### 작업 개요
<!--
  ex) 메인 피드에 게시글 기본 이미지가 뜨도록 수정
-->
회원가입 페이지에서 Checkbox가 체크되면 URL이 맞지 않아 이미지가 뜨지 않는 문제 해결

### 작업 분류
<!--
  - [ ] 버그 수정
  - [x] 신규 기능
  - [ ] 프로젝트 구조 변경
-->
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
<!--
  ex) 
  1. Feed/Post.js 이미지 없음 부분에 기본 이미지 추가함
-->
1. RegisterPage/RegisterPage.js에서 checkbox label 태그 안에 체크 시 checkbox 이미지 삽입
2. Sections/RegisterPage.css에서 직접 background image url 설정하는 코드 삭제

### 발생할 수 있는 문제
<!--
  ex) 
  1. 이미지를 모두 기본 이미지로 설정하여 실제 이미지가 있는 게시글도 기본 이미지로 뜰 것 같음
-->
