### PR TITLE
마이페이지에서 게시글 삭제 기능

### DIFF
--- a/client/src/components/Feed/Post.css
+++ b/client/src/components/Feed/Post.css
@@ -1,5 +1,6 @@
 /* 컨테이너 */
 .PreviewPostContainer {
+  position: relative;
   display: inline-flex;
   flex-direction: column;
   width: 391px;
@@ -14,6 +15,21 @@
 .MypagePostsPostContainer .PostDefaultImage {
   width: 350px;
   height: 285px;
+}
+
+/* 삭제 버튼 */
+.ButtonMypagePostDelete {
+  position: absolute;
+  width: 20px;
+  height: 20px;
+  top: 24px;
+  right: 24px;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+.ButtonMypagePostDelete:hover {
+  opacity: 0.5;
 }
 
 /* 이미지 없음 */

--- a/client/src/components/Feed/Post.js
+++ b/client/src/components/Feed/Post.js
@@ -62,6 +62,8 @@ function Post(props) {
     // 성공적으로 삭제되었다면
     if (res.status === 200) {
       // 게시글 목록 업데이트
+      props.onRemovePost(post._id);
+      alert("🗑 게시글이 삭제되었습니다!");
     }
   };
 

--- a/client/src/components/Feed/Post.js
+++ b/client/src/components/Feed/Post.js
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
+import axios from "axios";
 import { useHistory } from "react-router-dom";
 
 import "./Post.css";
@@ -19,6 +20,10 @@ function Post(props) {
   // 페이지 전환을 위한 Hook
   const history = useHistory();
   const onPostClick = (e) => {
+    if (buttonDeleteRef.current.contains(e.target)) {
+      return;
+    }
+
     // 게시글 미리보기 클릭
     // wezzle 혹은 mezzle
     const postType = post.isWezzle ? "wezzle" : "mezzle";
@@ -38,8 +43,41 @@ function Post(props) {
     return number;
   };
 
+  // 삭제 버튼 ref
+  const buttonDeleteRef = useRef();
+  // 게시글 삭제
+  const onDeletePost = async (e) => {
+    // 삭제 확인
+    if (!window.confirm("게시글을 삭제하시겠습니까?")) {
+      // 삭제 취소 시 리턴
+      return;
+    }
+
+    // 요청 url
+    const url = `/api/post/${post._id}`;
+
+    // 삭제 요청
+    const res = await axios.delete(url);
+
+    // 성공적으로 삭제되었다면
+    if (res.status === 200) {
+      // 게시글 목록 업데이트
+    }
+  };
+
   return (
     <article className={"PreviewPostContainer"} onClick={onPostClick}>
+      {/* Delete Button */}
+      {props.isMypage && (
+        <button
+          className={"ButtonMypagePostDelete"}
+          ref={buttonDeleteRef}
+          onClick={onDeletePost}
+        >
+          <img src="/images/myPage/post_delete.png" alt="delete" />
+        </button>
+      )}
+
       {/* 이미지가 있는지 없는지에 따라 기본 이미지 or 이미지 출력 */}
       {post.contents.images.length === 0 ? (
         // 이미지 없음

--- a/client/src/components/views/MyPage/Sections/MyPosts.js
+++ b/client/src/components/views/MyPage/Sections/MyPosts.js
@@ -107,6 +107,12 @@ function MyPosts({ currentMenu, isAuth, email }) {
     pagination.saveCurrentPage(location, setCurrentPage);
   }, [location]);
 
+  // 게시글 삭제 시 피드 업데이트
+  const onRemovePost = (postId) => {
+    const removedPosts = posts.filter((post) => post._id !== postId);
+    setPosts(removedPosts);
+  };
+
   return (
     // 글 전체 목록 컨테이너
     <section ref={scrollTargetRef} className={"MyPostsContainer"}>
@@ -130,6 +136,7 @@ function MyPosts({ currentMenu, isAuth, email }) {
                       post={post}
                       // 내 게시물일 때만 삭제 버튼 표시
                       isMypage={currentMenu === 1}
+                      onRemovePost={onRemovePost}
                     />
                   ))}
               </div>

--- a/client/src/components/views/MyPage/Sections/MyPosts.js
+++ b/client/src/components/views/MyPage/Sections/MyPosts.js
@@ -125,7 +125,12 @@ function MyPosts({ currentMenu, isAuth, email }) {
                 {pagination
                   .getCurrentPosts(currentPage, postsPerPage, posts)
                   .map((post, index) => (
-                    <Post key={index} post={post} />
+                    <Post
+                      key={index}
+                      post={post}
+                      // 내 게시물일 때만 삭제 버튼 표시
+                      isMypage={currentMenu === 1}
+                    />
                   ))}
               </div>
 


### PR DESCRIPTION
### 작업 개요
<!--
  ex) 메인 피드에 게시글 기본 이미지가 뜨도록 수정
-->
마이페이지에서 게시글을 삭제할 수 있도록 기능 추가

### 작업 분류
<!--
  - [ ] 버그 수정
  - [x] 신규 기능
  - [ ] 프로젝트 구조 변경
-->
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
<!--
  ex) 
  1. Feed/Post.js 이미지 없음 부분에 기본 이미지 추가함
-->
1. Feed/Post.js, Feed/Post.css에서 삭제 버튼 추가하고 CSS 작업
2. Feed/Post.js에서 삭제 후 게시글 업데이트 핸들러 추가
3. Sections/MyPosts.js에서 마이페이지 > 내 게시물일 때만 삭제 버튼 표시, 삭제 요청 핸들러 작성

### 발생할 수 있는 문제
<!--
  ex) 
  1. 이미지를 모두 기본 이미지로 설정하여 실제 이미지가 있는 게시글도 기본 이미지로 뜰 것 같음
-->
