### PR TITLE
Feed 에러 수정, 탈퇴 사용자, 마이페이지 게시글 삭제 권한

### DIFF
--- a/client/src/components/Feed/Post.js
+++ b/client/src/components/Feed/Post.js
@@ -21,8 +21,11 @@ function Post(props) {
   // 페이지 전환을 위한 Hook
   const history = useHistory();
   const onPostClick = (e) => {
-    if (buttonDeleteRef.current.contains(e.target)) {
-      return;
+    // delete 버튼 눌렀으면 (마이페이지)
+    if (buttonDeleteRef.current) {
+      if (buttonDeleteRef.current.contains(e.target)) {
+        return;
+      }
     }
 
     // 게시글 미리보기 클릭
@@ -34,7 +37,7 @@ function Post(props) {
   };
 
   // 삭제 버튼 ref
-  const buttonDeleteRef = useRef();
+  const buttonDeleteRef = useRef(null);
   // 게시글 삭제
   const onDeletePost = async (e) => {
     // 삭제 확인

--- a/client/src/components/views/Footer/Footer.js
+++ b/client/src/components/views/Footer/Footer.js
@@ -10,66 +10,64 @@ function Footer() {
   const user = useSelector((state) => state.user.authPayload);
 
   return (
-    user && (
-      <footer>
-        <div className="TopFooter">
-          {/* Duzzle 로고 이미지 */}
-          <div className="FooterLogo">
-            <img src="/images/footer/duzzle_white_logo.png" alt="logo" />
-          </div>
-
-          {/* SNS, Email, Menu */}
-          {/* SNS, Email */}
-          <div className="TopLeftFooter">
-            <div className="FooterSNS">
-              <a
-                href="https://www.instagram.com/duzzle.2021/"
-                target="_blank"
-                rel="noreferrer"
-                className="InstaText"
-              >
-                <img src="/images/footer/instagram.png" alt="" />
-              </a>
-              <a
-                href="https://www.facebook.com/profile.php?id=100068791056122"
-                target="_blank"
-                rel="noreferrer"
-                className="FacebookText"
-              >
-                <img src="/images/footer/facebook.png" alt="" />
-              </a>
-            </div>
-            <span>{"duzzlemanager@gmail.com"}</span>
-          </div>
-          {/* Menu */}
-          <div className="FooterMenu">
-            <span>Menu</span>
-            <div className="FooterMenuLinks">
-              <Link to={"/"}>home</Link>
-              <Link to={"/wezzle"}>wezzle</Link>
-              <Link to={`/users/${user.email}`}>mypage</Link>
-              <Link to={"/mezzle"}>mezzle</Link>
-            </div>
-          </div>
+    <footer>
+      <div className="TopFooter">
+        {/* Duzzle 로고 이미지 */}
+        <div className="FooterLogo">
+          <img src="/images/footer/duzzle_white_logo.png" alt="logo" />
         </div>
 
-        {/* divider */}
-        <hr className={"FooterDivider"} />
-
-        {/* 하단 푸터 (copyright, 개인정보처리방침) */}
-        <div className="BottomFooter">
-          <span>{"COPYRIGHT 2021. Duzzle All rights reserved."}</span>
-          <a
-            href="https://chohadam.tistory.com/3"
-            target="_blank"
-            rel="noreferrer"
-            className="InstaText"
-          >
-            개인정보처리방침
-          </a>
+        {/* SNS, Email, Menu */}
+        {/* SNS, Email */}
+        <div className="TopLeftFooter">
+          <div className="FooterSNS">
+            <a
+              href="https://www.instagram.com/duzzle.2021/"
+              target="_blank"
+              rel="noreferrer"
+              className="InstaText"
+            >
+              <img src="/images/footer/instagram.png" alt="" />
+            </a>
+            <a
+              href="https://www.facebook.com/profile.php?id=100068791056122"
+              target="_blank"
+              rel="noreferrer"
+              className="FacebookText"
+            >
+              <img src="/images/footer/facebook.png" alt="" />
+            </a>
+          </div>
+          <span>{"duzzlemanager@gmail.com"}</span>
         </div>
-      </footer>
-    )
+        {/* Menu */}
+        <div className="FooterMenu">
+          <span>Menu</span>
+          <div className="FooterMenuLinks">
+            <Link to={"/"}>home</Link>
+            <Link to={"/wezzle"}>wezzle</Link>
+            {user && <Link to={`/users/${user.email}`}>mypage</Link>}
+            <Link to={"/mezzle"}>mezzle</Link>
+          </div>
+        </div>
+      </div>
+
+      {/* divider */}
+      <hr className={"FooterDivider"} />
+
+      {/* 하단 푸터 (copyright, 개인정보처리방침) */}
+      <div className="BottomFooter">
+        <span>{"COPYRIGHT 2021. Duzzle All rights reserved."}</span>
+        <a
+          href="https://chohadam.tistory.com/3"
+          target="_blank"
+          rel="noreferrer"
+          className="InstaText"
+        >
+          개인정보처리방침
+        </a>
+      </div>
+    </footer>
   );
 }
 

--- a/client/src/components/views/MyPage/Sections/MyPosts.js
+++ b/client/src/components/views/MyPage/Sections/MyPosts.js
@@ -135,7 +135,7 @@ function MyPosts({ currentMenu, isAuth, email }) {
                       key={index}
                       post={post}
                       // 내 게시물일 때만 삭제 버튼 표시
-                      isMypage={currentMenu === 1}
+                      isMypage={currentMenu === 1 && isAuth}
                       onRemovePost={onRemovePost}
                     />
                   ))}

--- a/client/src/components/views/PostPage/Sections/Comment/Comment.js
+++ b/client/src/components/views/PostPage/Sections/Comment/Comment.js
@@ -84,23 +84,37 @@ function Comment(props) {
       // 댓글 하나의 컨테이너
       <div className="CommentContainer">
         {/* 댓글 유저, 댓글 게시 날짜, 내용 */}
-        {/* 댓글 유저 프로필 사진 */}
-        <img
-          className="CommentUserProfileImage"
-          src={comment.user.profileImage}
-          alt="commentUserProfileImage"
-        />
+        {/* 댓글 유저 프로필 사진 (없다면 탈퇴 사용자) */}
+        {comment.user._id ? (
+          <img
+            className="CommentUserProfileImage"
+            src={comment.user.profileImage}
+            alt="commentUserProfileImage"
+          />
+        ) : (
+          // 탈퇴한 사용자라면 기본 이미지 표시
+          <img
+            className="CommentUserProfileImage"
+            src="/images/default/profile/1.png"
+            alt="profile"
+          />
+        )}
 
         {!updatingComment ? (
           <>
             <div className="CommentMainContents">
               <div>
-                <Link
-                  to={`/users/${comment.user.email}`}
-                  className="CommentUser"
-                >
-                  {comment.user.name}
-                </Link>
+                {comment.user._id ? (
+                  <Link
+                    to={`/users/${comment.user.email}`}
+                    className="CommentUser"
+                  >
+                    {comment.user.name}
+                  </Link>
+                ) : (
+                  // 탈퇴한 사용자 처리
+                  <Link className="CommentUser">{comment.user.name}</Link>
+                )}
                 <span className="CommentDate">
                   {comment.createdAt.slice(0, 10)}
                 </span>

--- a/client/src/components/views/PostPage/Sections/Post/Post.js
+++ b/client/src/components/views/PostPage/Sections/Post/Post.js
@@ -90,13 +90,24 @@ function Post({ post, setPost }) {
         <article className="PostTopContents">
           {/* 글쓴이 정보 */}
           <div className="PostUser">
-            {/* 프로필 사진 */}
-            <img src={post.user.profileImage} alt="profile" />
+            {/* 프로필 사진 (null이면 탈퇴한 사용자) */}
+            {post.user.profileImage ? (
+              <img src={post.user.profileImage} alt="profile" />
+            ) : (
+              <img src="/images/default/profile/1.png" alt="profile" />
+            )}
             {/* 이름, 게시날짜 */}
             <div className="PostUserText">
-              <Link to={`/users/${post.user.email}`} className="PostUserName">
-                {post.user.name}
-              </Link>
+              {/* _id null이면 탈퇴한 사용자 */}
+              {post.user._id ? (
+                <Link to={`/users/${post.user.email}`} className="PostUserName">
+                  {post.user.name}
+                </Link>
+              ) : (
+                // 탈퇴한 사용자
+                // name: (탈퇴한 사용자)
+                <Link className="PostUserName">{post.user.name}</Link>
+              )}
               <span>{post.createdAt.slice(0, 10)}</span>
             </div>
           </div>

--- a/server/functions/auth.js
+++ b/server/functions/auth.js
@@ -18,7 +18,7 @@ const getUserInfo = async (userId) => {
     // 없다면 존재하지 않는 사용자
     return {
       _id: null,
-      name: "(없는 사용자)",
+      name: "(탈퇴한 사용자)",
       email: null,
       profileImage: null,
     };


### PR DESCRIPTION
### 작업 개요
<!--
  ex) 메인 피드에 게시글 기본 이미지가 뜨도록 수정
-->
Wezzle, Mezzle Footer return 없는 에러 수정
글, 댓글을 작성한 사용자가 탈퇴할 경우 보여지는 것 처리
마이페이지에서 게시글을 삭제할 때 자신의 게시글만 삭제할 수 있도록 처리

### 작업 분류
<!--
  - [ ] 버그 수정
  - [x] 신규 기능
  - [ ] 프로젝트 구조 변경
-->
- [x] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
<!--
  ex) 
  1. Feed/Post.js 이미지 없음 부분에 기본 이미지 추가함
-->
1. Feed/Post.js 에서 ref.current가 null일 경우 처리
2. Footer/Footer.js redux user 조건부 렌더링 Link 부분에만 적용
3. Sections/MyPosts.js isAuth가 true일 때만 삭제 버튼 표시 (자신의 마이페이지일 때)
4. Sections/Comment/Comment.js, Sections/Post/Post.js, functions/auth.js에 탈퇴한 사용자 처리

### 발생할 수 있는 문제
<!--
  ex) 
  1. 이미지를 모두 기본 이미지로 설정하여 실제 이미지가 있는 게시글도 기본 이미지로 뜰 것 같음
-->
탈퇴 후에 남은 글과 댓글은 직접 DB에 접속해 삭제하는 방법밖에 없다.