### PR TITLE
네비게이션 프로필 사진 동기화, 프로필 수정 로딩 화면

### DIFF
--- a/client/src/components/views/MyPage/Sections/EditProfile.js
+++ b/client/src/components/views/MyPage/Sections/EditProfile.js
@@ -4,6 +4,7 @@ import { useDispatch } from "react-redux";
 import { editUser } from "../../../../_actions/user_action";
 
 import Input from "./Input";
+import Loading from "../../../Loading/Loading";
 
 // CSS
 import "./EditProfile.css";
@@ -22,9 +23,14 @@ function EditProfile({ user, setUser, setIsEditing }) {
   // 프로필 이미지
   const [image, setImage] = useState(null);
 
+  const [isLoading, setIsLoading] = useState(false);
+
   // 실제 수정 요청 보내기
   const onEditSubmit = async (e) => {
     e.preventDefault();
+
+    // 로딩
+    setIsLoading(true);
 
     // 변경했다면 변경한 이미지 URL, 아니면 null
     const imageUrl = await onProfileHandler();
@@ -43,6 +49,10 @@ function EditProfile({ user, setUser, setIsEditing }) {
 
     // 회원정보 수정
     const response = await dispatch(editUser(body));
+
+    // 로딩 완료
+    setIsLoading(false);
+
     if (response.payload.editSuccess) {
       alert("수정되었습니다!");
       // 수정된 유저 저장
@@ -187,6 +197,9 @@ function EditProfile({ user, setUser, setIsEditing }) {
           완료하기
         </button>
       </form>
+
+      {/* 로딩 중이라면 (수정 요청 보낸 후) */}
+      {isLoading && <Loading />}
     </article>
   );
 }

--- a/client/src/components/views/NavBar/Sections/AuthMenu.js
+++ b/client/src/components/views/NavBar/Sections/AuthMenu.js
@@ -55,6 +55,24 @@ function AuthMenu(props) {
     });
   };
 
+  // editUser 정보 가져오기 (수정 시 업데이트 위해서)
+  const editUser = useSelector((state) => state.user.editPayload);
+  useEffect(() => {
+    // editUser가 있으면 수정을 했다는 뜻
+    if (editUser) {
+      // 수정이 성공했는지
+      if (editUser.editSuccess) {
+        // 새로운 프로필 이미지로 수정
+        setUser((prevUser) => {
+          return {
+            ...prevUser,
+            profileImage: editUser.profileImage,
+          };
+        });
+      }
+    }
+  }, [editUser]);
+
   return (
     <div id="AuthMenu">
       {/* 로그인 되었는지 */}

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -283,6 +283,7 @@ router.post("/api/users/edit", auth, (req, res) => {
         if (err) return res.json({ editSuccess: false });
         return res.status(200).send({
           editSuccess: true,
+          profileImage: req.body.profileImage,
         });
       }
     );


### PR DESCRIPTION
### 작업 개요
<!--
  ex) 메인 피드에 게시글 기본 이미지가 뜨도록 수정
-->
프로필 수정 시 로딩 화면 띄우기
프로필 수정 후 네비게이션 프로필 사진도 바꾸기

### 작업 분류
<!--
  - [ ] 버그 수정
  - [x] 신규 기능
  - [ ] 프로젝트 구조 변경
-->
- [x] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
<!--
  ex) 
  1. Feed/Post.js 이미지 없음 부분에 기본 이미지 추가함
-->
1. MyPage/Sections/EditProfile.js  로딩 화면 추가
2. NavBar/Sections/AuthMenu.js editPayload에서 수정된 이미지 정보 가져오기
3. routes/auth.js 수정 시 프로필 이미지도 전송하기

### 발생할 수 있는 문제
<!--
  ex) 
  1. 이미지를 모두 기본 이미지로 설정하여 실제 이미지가 있는 게시글도 기본 이미지로 뜰 것 같음
-->
이미지 문제라 local에서는 제대로 된 테스트가 이루어지지 않아 배포 후 확인해봐야 할 것 같다.
