### PR TITLE
랜딩 페이지 미디어쿼리

### DIFF
--- a/client/src/components/views/Footer/Sections/Footer.css
+++ b/client/src/components/views/Footer/Sections/Footer.css
@@ -155,3 +155,42 @@ footer {
   color: white;
   text-decoration: none;
 }
+
+@media (min-width: 320px) and (max-width: 480px) {
+  /* Footer Container */
+  footer {
+    padding: 0;
+    font-size: 10px;
+  }
+
+  .TopFooter {
+    display: none;
+  }
+
+  /* hr */
+  .FooterDivider {
+    display: none;
+  }
+
+  /* 하단 Footer (copyright, 개인정보처리방침) */
+  .BottomFooter {
+    display: flex;
+    flex-direction: column-reverse;
+    /* justify-content: space-between; */
+
+    padding: 6.8%;
+  }
+
+  /* copyright */
+  .BottomFooter > span {
+    font-size: 1.2em;
+    font-weight: normal;
+  }
+
+  /* 개인정보처리방침 */
+  .BottomFooter > a {
+    font-size: 1.4em;
+    margin-bottom: 10px;
+    text-decoration: underline;
+  }
+}

--- a/client/src/components/views/LandingPage/Sections/LandingImage.css
+++ b/client/src/components/views/LandingPage/Sections/LandingImage.css
@@ -19,3 +19,26 @@
   right: 0;
   bottom: 0;
 }
+
+@media (min-width: 320px) and (max-width: 480px) {
+  /* Container */
+  .LandingImage {
+    width: 100%;
+    position: relative;
+  }
+
+  /* browser */
+  .LandingImageBrowser {
+    width: 95%;
+    margin-right: 5%;
+    margin-bottom: 30px;
+  }
+
+  /* mypage */
+  .LandingImageMypage {
+    width: 40%;
+    position: absolute;
+    right: 0;
+    bottom: 0;
+  }
+}

--- a/client/src/components/views/LandingPage/Sections/LandingImage.js
+++ b/client/src/components/views/LandingPage/Sections/LandingImage.js
@@ -22,7 +22,7 @@ function LandingImage({ browser, mypage, startAnimation }) {
   const [mypageRef, onStartMypage, resetStyleMypage] = useAnimation(
     { transform: translateX },
     duration,
-    delay * 4
+    delay * 2
   );
 
   useEffect(() => {

--- a/client/src/components/views/LandingPage/Sections/LandingText.css
+++ b/client/src/components/views/LandingPage/Sections/LandingText.css
@@ -58,3 +58,37 @@ span.LandingTextAccent[data-color="blue"] {
 span.LandingTextAccent[data-color="orange"] {
   color: #ff5200;
 }
+
+@media (min-width: 320px) and (max-width: 480px) {
+  .LandingTextContainer {
+    width: 90%;
+  }
+
+  /* icon */
+  .LandingTextContainer > img {
+    width: 30px;
+  }
+
+  /* title1 */
+  h1.LandingTextTitle {
+    margin-top: 10px;
+    margin-bottom: 15px;
+    font-size: 2.4em;
+  }
+  /* title2 */
+  h2.LandingTextTitle {
+    margin-top: 35px;
+    margin-bottom: 15px;
+    font-size: 1.8em;
+  }
+
+  /* description */
+  .LandingTextDescription {
+    font-size: 1.2em;
+  }
+
+  .LandingTextDescription > span {
+    display: inline;
+    margin-right: 4px;
+  }
+}

--- a/client/src/components/views/LandingPage/Sections/WezzleMezzle.css
+++ b/client/src/components/views/LandingPage/Sections/WezzleMezzle.css
@@ -12,3 +12,11 @@
 .LandingWezzle {
   background-color: #f9f9f9;
 }
+
+@media (min-width: 320px) and (max-width: 480px) {
+  .LandingWezzleMezzle {
+    padding: 6.8%;
+    flex-direction: column;
+    justify-content: space-evenly;
+  }
+}


### PR DESCRIPTION
### 작업 개요
<!--
  ex) 메인 피드에 게시글 기본 이미지가 뜨도록 수정
-->
랜딩 페이지 Wezzle, Mezzle 부분, 푸터 부분 미디어쿼리(모바일) 적용

### 작업 분류
<!--
  - [ ] 버그 수정
  - [x] 신규 기능
  - [ ] 프로젝트 구조 변경
-->
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
<!--
  ex) 
  1. Feed/Post.js 이미지 없음 부분에 기본 이미지 추가함
-->
1. views/Footer/, views/LandingPage/ CSS 수정

### 발생할 수 있는 문제
<!--
  ex) 
  1. 이미지를 모두 기본 이미지로 설정하여 실제 이미지가 있는 게시글도 기본 이미지로 뜰 것 같음
-->
모바일 애니메이션이 제대로 나올지 확실하지 않음