### PR TITLE
회원가입 페이지 미디어쿼리

### DIFF
--- a/client/src/components/Feed/NonePosts.css
+++ b/client/src/components/Feed/NonePosts.css
@@ -43,15 +43,30 @@
 
 /* (juhyun-noh) 모바일용 미디어쿼리 */
 @media (max-width: 480px) {
+  /* 컨테이너 */
+  .NonePostsContainer {
+    padding-top: 145px;
+    padding-bottom: 45px;
+  }
+
+  /* 빈 폴더 아이콘 */
+  .NonePostsContainer img {
+    width: 100px;
+    margin-bottom: 40px;
+  }
+
   /* 없다는 설명 글 */
   .NonePostsContainer span {
-    font-size: 3em;
+    font-size: 2em;
+    line-height: 1.45;
   }
 
   /* 글 작성하기 버튼 */
   .NonePostsContainer a {
-    width: 200px;
-    height: 55px;
-    font-size: 2.2em;
+    width: 180px;
+    height: 60px;
+    margin-top: 60px;
+
+    font-size: 1.6em;
   }
 }

--- a/client/src/components/views/FeedPage/Sections/Posts.css
+++ b/client/src/components/views/FeedPage/Sections/Posts.css
@@ -138,6 +138,7 @@
     width: 100px;
     height: 40px;
 
+    border-width: 2px;
     border-radius: 60px;
     font-size: 1.5em;
 

--- a/client/src/components/views/RegisterPage/Sections/Popup.css
+++ b/client/src/components/views/RegisterPage/Sections/Popup.css
@@ -94,3 +94,44 @@
   font-size: 1.6em;
   font-weight: normal;
 }
+
+@media (max-width: 480px) {
+  /* 메인 컨텐츠 */
+  .PopupCard {
+    width: 80%;
+    height: 75%;
+
+    padding: 20px;
+
+    border-radius: 10px;
+  }
+
+  .TopContents h3 {
+    font-size: 1.6em;
+  }
+
+  .PopupDescription {
+    font-size: 1.2em;
+  }
+
+  /* 캔슬 버튼 */
+  .ExitButton {
+    padding: 0;
+    width: 16px;
+    height: 16px;
+  }
+  .ExitButton img {
+    width: 100%;
+    height: 100%;
+  }
+
+  /* 개인정보취급방침 텍스트 */
+  /* 스크롤 컨테이너 */
+  .AgreeTextContainer {
+    padding: 10px 15px;
+  }
+
+  .AgreeText {
+    font-size: 1em;
+  }
+}

--- a/client/src/components/views/RegisterPage/Sections/RegisterPage.css
+++ b/client/src/components/views/RegisterPage/Sections/RegisterPage.css
@@ -222,3 +222,106 @@ input[id="agree"] {
 .RegisterSubmit:focus {
   outline: none;
 }
+
+@media (max-width: 480px) {
+  /* 카드 영역 */
+  .CardContainer {
+    width: 75vw;
+    height: 80vh;
+    flex-direction: column;
+    font-size: 10px;
+  }
+
+  /* 왼쪽 영역 */
+  .Description {
+    width: 100%;
+  }
+
+  /* 왼쪽 영역 텍스트들 */
+  .TextContainer {
+    text-align: center;
+    font-size: 1.2em;
+    margin-top: 10px;
+    margin-left: 0;
+    margin-bottom: 10px;
+  }
+
+  /* 더즐과 함께 더 즐겨보세요! */
+  .Accent {
+    font-size: 1.6em;
+    margin-bottom: 10px;
+  }
+
+  /* 퍼즐 이미지 */
+  .Puzzle {
+    display: none;
+  }
+
+  /* 오른쪽 영역 */
+  .SignUpContainer {
+    width: 100%;
+    height: 100%;
+  }
+
+  /* 회원가입 form */
+  .SignUpForm {
+    width: 80%;
+    height: 90%;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  /* 회원가입 */
+  .SignUpForm h1 {
+    font-size: 1.6em;
+  }
+
+  /* 이메일, 비밀번호, 비밀번호 확인 */
+  .SignUpForm > label:nth-child(-n + 4) {
+    width: 100%;
+    flex-direction: column;
+
+    font-size: 1.4em;
+    margin-top: 10px;
+  }
+
+  .SignUpForm > label > div {
+    margin-top: 5px;
+    width: 100%;
+  }
+
+  /* 이메일, 비밀번호, 비밀번호 확인, submit button */
+  .RegisterInput {
+    padding-left: 15px;
+    font-size: 12px;
+  }
+
+  .RegisterInput::placeholder {
+    font-size: 12px;
+  }
+
+  /* 경고 문구 */
+  .WarningContainer img {
+    width: 13px;
+  }
+
+  /* 개인정보 수집 및 이용 동의 체크박스 */
+  .AgreeContainer {
+    margin-top: 10px;
+  }
+  .AgreeLink {
+    font-size: 14px;
+  }
+
+  /* Button JOIN */
+  .RegisterSubmit {
+    width: 100%;
+    height: 35px;
+    margin-top: 15px;
+
+    font-size: 14px;
+    font-weight: bold;
+  }
+}


### PR DESCRIPTION
### 작업 개요
<!--
  ex) 메인 피드에 게시글 기본 이미지가 뜨도록 수정
-->
회원가입 및 개인정보동의 팝업 창 미디어쿼리 적용

### 작업 분류
<!--
  - [ ] 버그 수정
  - [x] 신규 기능
  - [ ] 프로젝트 구조 변경
-->
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
<!--
  ex) 
  1. Feed/Post.js 이미지 없음 부분에 기본 이미지 추가함
-->
1. RegisterPage/Sections/RegisterPage.css, Popup.css 미디어쿼리

### 발생할 수 있는 문제
<!--
  ex) 
  1. 이미지를 모두 기본 이미지로 설정하여 실제 이미지가 있는 게시글도 기본 이미지로 뜰 것 같음
-->
